### PR TITLE
Simplify test generation

### DIFF
--- a/bin/codegen
+++ b/bin/codegen
@@ -1,0 +1,1 @@
+pipenv run playwright codegen localhost:5001 --target=python-pytest

--- a/bin/codegen_helper
+++ b/bin/codegen_helper
@@ -1,0 +1,1 @@
+pipenv run pytest tests/helpers/generator.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,15 @@ from app import db as _db
 pytest_plugins = ["fixtures"]
 
 
+# @pytest.fixture(scope="session")
+# def browser_context_args(browser_context_args):
+#     return {
+#         **browser_context_args,
+#         "storage_state": "tests/helpers/auth.json",
+#         "ignore_https_errors": True,
+#     }
+
+
 @pytest.fixture(scope="session")
 def app():
     application = create_app(config_name="testing")

--- a/tests/helpers/generator.py
+++ b/tests/helpers/generator.py
@@ -1,0 +1,5 @@
+def test_generator_helper(live_server):
+    import time
+
+    while True:
+        time.sleep(10000)


### PR DESCRIPTION
Pro generování E2E testů používáme Playwright. Ten umí snadné nahrávání testů.  
Přidal jsem helpery:
Spusť `bin/codegen_helper` - ten spustí live_server na `localhost:5001`
Spusť `bin/codegen` - ten spustí samotné generování testu