### PR TITLE
Make links inside event warnings turbo frame leave frame, change link_to helper to enable this

### DIFF
--- a/app/components/links.py
+++ b/app/components/links.py
@@ -32,12 +32,16 @@ class CancelLink(Link):
 
 
 # helpers
-def link_to(obj_or_str, **kwargs):
+def link_to(obj_or_str, turbo=True, **kwargs):
     path = _get_path(obj_or_str)
 
     value = kwargs.pop("value", None)
     if not value:
         value = obj_or_str.default_link_value
+
+    if turbo is False:
+        kwargs["data"] = kwargs.get("data", {})
+        kwargs["data"]["turbo-frame"] = "_top"
 
     return Link(path=path, value=value, **kwargs).render()
 

--- a/app/templates/daily_plans/_recipe_row.html.j2
+++ b/app/templates/daily_plans/_recipe_row.html.j2
@@ -6,7 +6,7 @@
 
     <td>
         {% if not daily_recipe.is_shopping %}
-            {{ link_to(daily_recipe.recipe, portion_count=daily_recipe.portion_count, data={"turbo-frame": "_top"}) }}
+            {{ link_to(daily_recipe.recipe, portion_count=daily_recipe.portion_count, turbo=False) }}
         {% else %}
             {{ daily_recipe.recipe.name }}
         {% endif %}

--- a/app/templates/events/_warnings.html.j2
+++ b/app/templates/events/_warnings.html.j2
@@ -12,32 +12,32 @@
 
 		{% if event.zero_amount_ingredient_recipes %}
 			{% for recipe in event.zero_amount_ingredient_recipes %}
-				<li> {{ link_to(recipe) }} má surovinu s nulovou hodnotou </li>
+				<li> {{ link_to(recipe, turbo=False) }} má surovinu s nulovou hodnotou </li>
 			{% endfor %}
 		{% endif %}
 
 		{% if event.empty_recipes %}
 			{% for recipe in event.empty_recipes %}
-				<li> {{ link_to(recipe) }} nemá suroviny </li>
+				<li> {{ link_to(recipe, turbo=False) }} nemá suroviny </li>
 			{% endfor %}
 		{% endif %}
 
 		{% if event.no_measurement_ingredient_recipes %}
 			{% for recipe in event.no_measurement_ingredient_recipes %}
-				<li> {{ link_to(recipe) }} má surovinu bez metrik ({{ link_to(recipe.no_measurement_ingredients[0]) }}) </li>
+				<li> {{ link_to(recipe, turbo=False) }} má surovinu bez metrik ({{ link_to(recipe.no_measurement_ingredients[0]) }}) </li>
 			{% endfor %}
 		{% endif %}
 
 		{% if event.no_category_ingredient_recipes %}
 			{% for recipe in event.no_category_ingredient_recipes %}
-				<li> {{ link_to(recipe) }} má surovinu bez kategorie ({{ link_to(recipe.no_category_ingredients[0]) }}) </li>
+				<li> {{ link_to(recipe, turbo=False) }} má surovinu bez kategorie ({{ link_to(recipe.no_category_ingredients[0]) }}) </li>
 			{% endfor %}
 		{% endif %}
 
 
 		{% if event.recipes_without_category %}
 			{% for recipe in event.recipes_without_category %}
-				<li> {{ link_to(recipe) }} nemá kategorii </li>
+				<li> {{ link_to(recipe, turbo=False) }} nemá kategorii </li>
 			{% endfor %}
 		{% endif %}
 	


### PR DESCRIPTION
Call `link_to` with `turbo=False` kwarg to make it use `data-turbo-frame="_top"`
It's little weird - `turbo=False` should disable turbo on this link probably, but I don't do that, so this makes sorta sense. 