### PR TITLE
Remove event zero ingredient warning

### DIFF
--- a/app/models/events.py
+++ b/app/models/events.py
@@ -159,10 +159,6 @@ class Event(BaseModel, BaseMixin, Loggable, Attendable, Collaborative, EventPres
         return split_recipes
 
     @property
-    def zero_amount_ingredient_recipes(self) -> list:
-        return [r for r in self.active_recipes if r.has_zero_amount_ingredient]
-
-    @property
     def no_measurement_ingredient_recipes(self) -> list:
         return [r for r in self.active_recipes if r.has_no_measurement_ingredient]
 

--- a/app/templates/events/_warnings.html.j2
+++ b/app/templates/events/_warnings.html.j2
@@ -1,18 +1,11 @@
 <turbo-frame id="event-warnings">
-	{% if event.zero_amount_ingredient_recipes
-		  or event.empty_recipes
+	{% if event.empty_recipes
 		  or event.no_measurement_ingredient_recipes
 		  or event.no_category_ingredient_recipes
 		  or event.recipes_without_category %}
 
 	<div class="warning m-2 mt-4 p-2 pb-3 pt-3 text-center">
 		<h3 class="text-uppercase font-comfortaa"> Upozornění </h3>
-
-		{% if event.zero_amount_ingredient_recipes %}
-			{% for recipe in event.zero_amount_ingredient_recipes %}
-				<li> {{ link_to(recipe, turbo=False) }} má surovinu s nulovou hodnotou </li>
-			{% endfor %}
-		{% endif %}
 
 		{% if event.empty_recipes %}
 			{% for recipe in event.empty_recipes %}


### PR DESCRIPTION
Protože jsem zrušil "ingredient not measured", ale prostě to člověk nechá prázdný, nedává smysl na to mít warning.